### PR TITLE
Scan coinjoin tx funds flow only

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -43,7 +43,7 @@ func TransactionFundsFlow(tx *rpcutils.Transaction) ([]*AllFundsFlows,
 	// If tx is complex exit
 	if isTxComplex(inputs, outputs) {
 		if setLog <= slog.LevelInfo {
-			log.Infof("Found tx %s to be complex thus could not be analyzed", tx.TxID)
+			log.Infof("Complex tx %s could not be analyzed", tx.TxID)
 		}
 
 		return []*AllFundsFlows{

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -136,6 +136,12 @@ func TxFundsFlowProbability(rawData []*AllFundsFlows,
 		return nil
 	}
 
+	if len(rawData) == 1 && rawData[0].StatusMsg != "" {
+		return []*FlowProbability{
+			&FlowProbability{StatusMsg: rawData[0].StatusMsg},
+		}
+	}
+
 	// Append the amounts count to the raw source inputs slice.
 	inSourceArr := appendDupsCount(rawInSourceArr)
 

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -18,8 +18,8 @@ func TransactionFundsFlow(tx *rpcutils.Transaction) ([]*AllFundsFlows,
 	[]float64, []float64, error) {
 	// setLog helps avoid pushing too many log statements to the heap.
 	setLog := log.Level()
-	if setLog <= slog.LevelDebug {
-		log.Infof("Anaylyzing %s data. Please Wait...", tx.TxID)
+	if setLog <= slog.LevelInfo {
+		log.Infof("Analyzing %s data. Please Wait...", tx.TxID)
 	}
 
 	// Retrieve the inputs and outputs from the transaction's data.
@@ -37,8 +37,10 @@ func TransactionFundsFlow(tx *rpcutils.Transaction) ([]*AllFundsFlows,
 	// minimum possible values.
 	granularBuckets, inputs, outputs := getPrefabricatedBuckets(originalInputs, originalOutputs)
 
-	log.Infof("Found %d prefabricated granular buckets from inputs and outputs",
-		len(granularBuckets))
+	if setLog <= slog.LevelInfo {
+		log.Infof("Found %d prefabricated granular buckets from inputs and outputs",
+			len(granularBuckets))
+	}
 
 	// If tx is complex exit
 	if isTxComplex(inputs, outputs) {
@@ -85,7 +87,7 @@ func TransactionFundsFlow(tx *rpcutils.Transaction) ([]*AllFundsFlows,
 
 	matchedSum := defBinaryTree.FindX(inputCombinations, tx.Fees)
 	if setLog <= slog.LevelInfo {
-		log.Trace("Matching the inputs and outputs selected to generate a solution(s)")
+		log.Info("Matching the inputs and outputs selected to generate a solution(s)")
 	}
 
 	solutionsChan := make(chan []*AllFundsFlows)

--- a/analytics/analyticstypes.go
+++ b/analytics/analyticstypes.go
@@ -66,9 +66,9 @@ type Set struct {
 	// hubCount helps track which hub has already been processed.
 	hubCount int
 
-	PercentOfInputs     float64
-	PathPercentOfInputs float64
-	Inputs              []*Hub
+	PathPercentOfInputs  float64
+	LevelPercentOfInputs float64
+	Inputs               []*Hub
 }
 
 // GroupedValues clusters together values as duplicates or other grouped values.

--- a/analytics/analyticstypes.go
+++ b/analytics/analyticstypes.go
@@ -65,6 +65,7 @@ type Set struct {
 
 	Inputs          []*Hub
 	PercentOfInputs float64
+	StatusMsg       string `json:",omitempty"`
 }
 
 // GroupedValues clusters together values as duplicates or other grouped values.

--- a/analytics/analyticstypes.go
+++ b/analytics/analyticstypes.go
@@ -16,7 +16,13 @@ const (
 	// outpointData defines the ouput type of data.
 	outpointData txProperties = "outputs"
 
-	complexTransaction = 20
+	// txComplexityMeasure defines the number of unique transactions that may take
+	// too long to process than needed. They may have a minimum probability of 5%.
+	txComplexityMeasure = 20
+
+	// complexTxMsg refers to the default message returned if a transaction cannot
+	// be processed as fast as possible.
+	complexTxMsg = "This txo is less then 5% traceable"
 )
 
 type txProperties string

--- a/analytics/analyticstypes.go
+++ b/analytics/analyticstypes.go
@@ -22,7 +22,7 @@ const (
 
 	// complexTxMsg refers to the default message returned if a transaction cannot
 	// be processed as fast as possible.
-	complexTxMsg = "This txo is less then 5% traceable"
+	complexTxMsg = "This txo is too complex to be analyzed now"
 )
 
 type txProperties string
@@ -41,13 +41,16 @@ type Node struct {
 // output TxHash to back in time where the source of funds can be identified.
 type Hub struct {
 	// Unique details of the current output.
-	Address string
+	address string
 	Amount  float64
 	TxHash  string
+	Vout    uint32
 
 	// Probability Types
-	PathProbability float64 `json:",omitempty"`
-	hubProbability  float64
+	PathProbability  float64 `json:",omitempty"`
+	LevelProbability float64 `json:",omitempty"`
+
+	StatusMsg string `json:",omitempty"`
 
 	// setCount helps track which set whose entry has already been processed
 	// in a specific Hub.
@@ -63,9 +66,9 @@ type Set struct {
 	// hubCount helps track which hub has already been processed.
 	hubCount int
 
-	Inputs          []*Hub
-	PercentOfInputs float64
-	StatusMsg       string `json:",omitempty"`
+	PercentOfInputs     float64
+	PathPercentOfInputs float64
+	Inputs              []*Hub
 }
 
 // GroupedValues clusters together values as duplicates or other grouped values.
@@ -120,9 +123,9 @@ type FlowProbability struct {
 	OutputAmount       float64
 	Count              int
 	LinkingProbability float64
-	ProbableInputs     []*InputSets
+	ProbableInputs     []*InputSets `json:",omitempty"`
+	StatusMsg          string       `json:",omitempty"`
 	uniqueInputs       map[float64]int
-	StatusMsg          string `json:",omitempty"`
 }
 
 // custom sort interface that sorts by Possible inputs in the probability set

--- a/analytics/chains.go
+++ b/analytics/chains.go
@@ -45,10 +45,10 @@ func RetrieveTxProbability(client *rpcclient.Client, txHash string) (
 }
 
 // ChainDiscovery returns all the possible chains associated with the tx hash used.
-func ChainDiscovery(client *rpcclient.Client, txHash string, outputIndex ...int) ([]*Hub, error) {
+func ChainDiscovery(client *rpcclient.Client, txHash string, outputIndex ...int) ([]*Hub, int64, error) {
 	tx, err := RetrieveTxData(client, txHash)
 	if err != nil {
-		return nil, err
+		return nil, tx.BlockTime, err
 	}
 
 	// hubsChain defines the various paths with funds flows from a given output to
@@ -56,8 +56,6 @@ func ChainDiscovery(client *rpcclient.Client, txHash string, outputIndex ...int)
 	var hubsChain []*Hub
 
 	var outPoints []rpcutils.TxOutput
-
-	var depth = 10
 
 	switch {
 	// OutputIndex has been provided
@@ -82,17 +80,18 @@ func ChainDiscovery(client *rpcclient.Client, txHash string, outputIndex ...int)
 		var stackTrace []*Hub
 
 		count := 1
-		pathOdds := 1.0
+		pathOdds, pathPOI := 1.0, 1.0
 
 		entry := &Hub{
 			TxHash:  tx.TxID,
 			Amount:  val.Value,
-			Address: val.PkScriptData.Addresses[0],
+			Vout:    val.TxIndex,
+			address: val.PkScriptData.Addresses[0],
 		}
 
-		err = handleDepths(entry, stackTrace, client, count, depth, pathOdds)
+		err = handleDepths(entry, stackTrace, client, count, pathOdds, pathPOI)
 		if err != nil {
-			return nil, err
+			return nil, tx.BlockTime, err
 		}
 
 		hubsChain = append(hubsChain, entry)
@@ -100,31 +99,37 @@ func ChainDiscovery(client *rpcclient.Client, txHash string, outputIndex ...int)
 
 	log.Info("Finished auto chain(s) discovery and appending all needed data")
 
-	return hubsChain, nil
+	return hubsChain, tx.BlockTime, nil
 }
 
 // handleDepths recusively creates a graph-like data structure that shows the
 // funds flow path from output (UTXO) to the source of funds at the provided depth.
 // totalOdds defines the effective path probability at the current depth.
-func handleDepths(curHub *Hub, stack []*Hub, client *rpcclient.Client, count, depth int,
-	totalOdds float64) error {
-	err := curHub.getDepth(client)
+func handleDepths(curHub *Hub, stack []*Hub, client *rpcclient.Client, count int,
+	totalOdds, pathPOI float64) error {
+	pathPOI, err := curHub.getDepth(client, pathPOI)
 	if err != nil {
 		return err
 	}
 
-	if curHub.hubProbability > 0 {
-		totalOdds = roundOff(totalOdds * curHub.hubProbability)
+	if curHub.LevelProbability > 0 {
+		totalOdds = roundOff(totalOdds * curHub.LevelProbability)
 		curHub.PathProbability = totalOdds
 	}
 
-	if curHub.hubProbability == 1 || depth == count || curHub.TxHash == "" {
-		// backtrack till we find an unprocessed Hub.
-		if curHub.hubProbability > 0 {
-			totalOdds = roundOff(totalOdds / curHub.hubProbability)
+	// backtrack till we find an unprocessed Hub. LevelProbability should lie
+	// between 1 and 0.
+	if curHub.LevelProbability == 1 || curHub.PathProbability == 0 ||
+		curHub.TxHash == "" || curHub.StatusMsg != "" {
+		if curHub.LevelProbability > 0 {
+			totalOdds = roundOff(totalOdds / curHub.LevelProbability)
 		}
 
 		for {
+			if len(stack) == 0 {
+				return nil
+			}
+
 			count--
 			curHub = stack[len(stack)-1]
 			stack = stack[:len(stack)-1]
@@ -137,10 +142,6 @@ func handleDepths(curHub *Hub, stack []*Hub, client *rpcclient.Client, count, de
 				curHub.setCount++
 				break
 			}
-
-			if len(stack) == 0 {
-				return nil
-			}
 		}
 	}
 
@@ -149,65 +150,72 @@ func handleDepths(curHub *Hub, stack []*Hub, client *rpcclient.Client, count, de
 	curHub = curHub.Matched[curHub.setCount].
 		Inputs[curHub.Matched[curHub.setCount].hubCount]
 
-	return handleDepths(curHub, stack, client, count+1, depth, totalOdds)
+	return handleDepths(curHub, stack, client, count+1, totalOdds, pathPOI)
 }
 
 // getDepth appends all the sets linked to a given output after a given amount
 // probability solution is resolved.
-func (h *Hub) getDepth(client *rpcclient.Client) error {
+func (h *Hub) getDepth(client *rpcclient.Client, pathPOI float64) (float64, error) {
 	if h.TxHash == "" {
-		return nil
+		return pathPOI, nil
 	}
 
 	probabilityData, tx, err := RetrieveTxProbability(client, h.TxHash)
 	if err != nil {
-		return err
+		return pathPOI, err
 	}
 
 	for _, item := range probabilityData {
 		if item.OutputAmount == h.Amount {
 			for _, entry := range item.ProbableInputs {
-				d, err := getSet(client, tx, entry)
+				d, err := getSet(client, tx, entry, pathPOI)
 				if err != nil {
-					return err
+					return pathPOI, err
 				}
 
-				h.hubProbability = item.LinkingProbability
+				h.LevelProbability = item.LinkingProbability
 				h.Matched = append(h.Matched, d)
 			}
 		}
+
+		if item.StatusMsg != "" {
+			h.StatusMsg = item.StatusMsg
+		}
 	}
-	return nil
+	return pathPOI, nil
 }
 
 // The Set returned in a given output probability solution does not have a lot of
 // data, this functions reconstructs the Set adding the necessary information.
 func getSet(client *rpcclient.Client, txData *rpcutils.Transaction,
-	matchedInputs *InputSets) (set Set, err error) {
+	matchedInputs *InputSets, pathPOI float64) (set Set, err error) {
 	inputs := make([]rpcutils.TxInput, len(txData.Inpoints))
 	copy(inputs, txData.Inpoints)
 
 	for _, item := range matchedInputs.Set {
+		pathPOI = roundOff(pathPOI * matchedInputs.PercentOfInputs)
+
 		for i := 0; i < item.PossibleInputs; i++ {
 			for k, d := range inputs {
 				if d.ValueIn == item.Amount {
-					s := &Hub{Amount: d.ValueIn, TxHash: d.TxHash}
-
-					tx, err := RetrieveTxData(client, s.TxHash)
+					tx, err := RetrieveTxData(client, d.TxHash)
 					if err != nil {
 						return Set{}, err
 					}
 
+					s := &Hub{Amount: d.ValueIn, TxHash: d.TxHash, Vout: d.OutputTxIndex}
+
 					// fetch the current hub's Address.
 					for k := range tx.Outpoints {
 						if d.OutputTxIndex == tx.Outpoints[k].TxIndex {
-							s.Address = tx.Outpoints[k].PkScriptData.Addresses[0]
+							s.address = tx.Outpoints[k].PkScriptData.Addresses[0]
+							break
 						}
 					}
 
 					set.Inputs = append(set.Inputs, s)
 					set.PercentOfInputs = matchedInputs.PercentOfInputs
-					set.StatusMsg = matchedInputs.StatusMsg
+					set.PathPercentOfInputs = pathPOI
 
 					copy(inputs[k:], inputs[k+1:])
 					inputs = inputs[:len(inputs)-1]

--- a/analytics/chains.go
+++ b/analytics/chains.go
@@ -207,6 +207,7 @@ func getSet(client *rpcclient.Client, txData *rpcutils.Transaction,
 
 					set.Inputs = append(set.Inputs, s)
 					set.PercentOfInputs = matchedInputs.PercentOfInputs
+					set.StatusMsg = matchedInputs.StatusMsg
 
 					copy(inputs[k:], inputs[k+1:])
 					inputs = inputs[:len(inputs)-1]

--- a/analytics/chains.go
+++ b/analytics/chains.go
@@ -57,7 +57,7 @@ func ChainDiscovery(client *rpcclient.Client, txHash string, outputIndex ...int)
 
 	var outPoints []rpcutils.TxOutput
 
-	var depth = 5
+	var depth = 10
 
 	switch {
 	// OutputIndex has been provided

--- a/analytics/internals.go
+++ b/analytics/internals.go
@@ -371,3 +371,21 @@ func getPrefabricatedBuckets(inputs, outputs []float64) (
 
 	return
 }
+
+// isTxComplex returns true if the number of unique amounts in either inputs or
+// outputs is greater than the set transaction complexity measure. Transaction
+// complexity measure refers to the maximum number of unique inputs or outputs
+// that can be processed using the combinations method in reasonably short time.
+func isTxComplex(inputs, outputs []float64) bool {
+	uniqueInputs := GroupDuplicates(inputs)
+	if len(uniqueInputs) > txComplexityMeasure {
+		return true
+	}
+
+	uniqueOutputs := GroupDuplicates(outputs)
+	if len(uniqueOutputs) > txComplexityMeasure {
+		return true
+	}
+
+	return false
+}

--- a/explorer.go
+++ b/explorer.go
@@ -26,7 +26,7 @@ const (
 		`"single path": "/api/v1/{tx}/chain/{index}"}`
 
 	defaultErrorMsg = `{"error": "Oops! Something went wrong, try different ` +
-		`inputs or contact system maintainers if problem persist.",` +
+		`inputs or contact system maintainers if problem persists.",` +
 		`"duration":"%s"}`
 )
 

--- a/explorer.go
+++ b/explorer.go
@@ -9,6 +9,7 @@ import (
 	"net/http/pprof"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/decred/dcrd/rpcclient"
 	"github.com/gorilla/mux"
@@ -24,9 +25,17 @@ const (
 		`"all paths": "/api/v1/{tx}/chain",` +
 		`"single path": "/api/v1/{tx}/chain/{index}"}`
 
-	defaultErrorMsg = `{"error": "Oops! Something went wrong, try different` +
-		` inputs or contact system maintainers if problem persist."}`
+	defaultErrorMsg = `{"error": "Oops! Something went wrong, try different ` +
+		`inputs or contact system maintainers if problem persist.",` +
+		`"duration":"%s"}`
 )
+
+// TimeData defines the time data type that holds the block time from the
+// actual tx and time taken to process a given payload.
+type TimeData struct {
+	BlockTime int64  `json:",omitempty"`
+	Duration  string `json:",omitempty"`
+}
 
 // explorer defines all the content needed to effectively serve http requests.
 type explorer struct {
@@ -36,94 +45,110 @@ type explorer struct {
 	OtherParams *extraParams
 }
 
+// rawSolution defines the full structure of final raw solution(single tx
+// analyzed solution).
+type rawSolution struct {
+	TimeData
+	Data []*analytics.AllFundsFlows
+}
+
+// probabilitySolution defines the full structure of the probability solution
+// for a single tx that is based of the raw data solution.
+type probabilitySolution struct {
+	TimeData
+	Data []*analytics.FlowProbability
+}
+
+// pathSolution is the funds flow solution that just a chain of probability
+// solutions linked together.
+type pathSolution struct {
+	TimeData
+	Data []*analytics.Hub
+}
+
 // healthHandler helps checks if the system is up and running.
 func (exp *explorer) HealthHandler(w http.ResponseWriter, r *http.Request) {
-	healthMsg := []byte(healthMsg)
-
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(http.StatusOK)
-	w.Write(healthMsg)
+	jsonWrite([]byte(healthMsg), http.StatusOK, w)
 }
 
 // StatusHandler handles the various system statuses supported.
-func (exp *explorer) StatusHandler(w http.ResponseWriter, r *http.Request, err error) {
+func (exp *explorer) StatusHandler(w http.ResponseWriter, r *http.Request,
+	startTime time.Time, err error) {
 	log.Error(err)
-	logErrorMsg := []byte(defaultErrorMsg)
 
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(http.StatusUnprocessableEntity)
-	w.Write(logErrorMsg)
+	data := fmt.Sprintf(defaultErrorMsg, time.Since(startTime).String())
+	jsonWrite([]byte(data), http.StatusUnprocessableEntity, w)
 }
 
 // AllTxSolutionsHandler fetches analyzed transactions inputs and outputs returning
-// all the possible solutions generated.
+// all the possible solutions generated(raw tx solution).
 func (exp *explorer) AllTxSolutionsHandler(w http.ResponseWriter, r *http.Request) {
 	transactionX := mux.Vars(r)["tx"]
+	t := time.Now()
 
 	txData, err := analytics.RetrieveTxData(exp.Client, transactionX)
 	if err != nil {
-		exp.StatusHandler(w, r, err)
+		exp.StatusHandler(w, r, t, err)
 		return
 	}
 
 	rawTxSolution, _, _, err := analytics.TransactionFundsFlow(txData)
 	if err != nil {
-		exp.StatusHandler(w, r, err)
+		exp.StatusHandler(w, r, t, err)
 		return
 	}
 
-	strData, err := json.Marshal(rawTxSolution)
-	if err != nil {
-		exp.StatusHandler(w, r, fmt.Errorf("error occured: %v", err))
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(http.StatusOK)
-	w.Write(strData)
+	exp.handleJSONWrite(
+		rawSolution{
+			Data: rawTxSolution,
+			TimeData: TimeData{
+				BlockTime: txData.BlockTime, Duration: time.Since(t).String(),
+			},
+		},
+		http.StatusOK, t, w, r)
 }
 
 // TxProbabilityHandler from the fetched analyzed solutions, it returns the solution
 // with the lowest granularity as the best solution.
 func (exp *explorer) TxProbabilityHandler(w http.ResponseWriter, r *http.Request) {
 	transactionX := mux.Vars(r)["tx"]
+	t := time.Now()
 
-	solProbability, _, err := analytics.RetrieveTxProbability(exp.Client, transactionX)
+	solProbability, txData, err := analytics.RetrieveTxProbability(exp.Client, transactionX)
 	if err != nil {
-		exp.StatusHandler(w, r, err)
+		exp.StatusHandler(w, r, t, err)
 		return
 	}
 
-	strData, err := json.Marshal(solProbability)
-	if err != nil {
-		exp.StatusHandler(w, r, fmt.Errorf("error occured: %v", err))
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(http.StatusOK)
-	w.Write(strData)
+	exp.handleJSONWrite(
+		probabilitySolution{
+			Data: solProbability,
+			TimeData: TimeData{
+				BlockTime: txData.BlockTime, Duration: time.Since(t).String(),
+			},
+		},
+		http.StatusOK, t, w, r)
 }
 
 // ChainHandler reconstructs the probability solution to create funds flow paths.
 func (exp *explorer) ChainHandler(w http.ResponseWriter, r *http.Request) {
 	transactionX := mux.Vars(r)["tx"]
+	t := time.Now()
 
-	chain, err := analytics.ChainDiscovery(exp.Client, transactionX)
+	chain, blockTime, err := analytics.ChainDiscovery(exp.Client, transactionX)
 	if err != nil {
-		exp.StatusHandler(w, r, err)
+		exp.StatusHandler(w, r, t, err)
 		return
 	}
 
-	strData, err := json.Marshal(chain)
-	if err != nil {
-		exp.StatusHandler(w, r, fmt.Errorf("error occured: %v", err))
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(http.StatusOK)
-	w.Write(strData)
+	exp.handleJSONWrite(
+		pathSolution{
+			Data: chain,
+			TimeData: TimeData{
+				BlockTime: blockTime, Duration: time.Since(t).String(),
+			},
+		},
+		http.StatusOK, t, w, r)
 }
 
 // ChainPathHandler reconstructs the probability solution to create one funds
@@ -131,28 +156,28 @@ func (exp *explorer) ChainHandler(w http.ResponseWriter, r *http.Request) {
 // the available output index, the outputs path with the last index is returned.
 func (exp *explorer) ChainPathHandler(w http.ResponseWriter, r *http.Request) {
 	transactionX := mux.Vars(r)["tx"]
+	t := time.Now()
 
 	txIndex, err := strconv.Atoi(mux.Vars(r)["index"])
 	if err != nil {
-		exp.StatusHandler(w, r, err)
+		exp.StatusHandler(w, r, t, err)
 		return
 	}
 
-	chain, err := analytics.ChainDiscovery(exp.Client, transactionX, txIndex)
+	chain, blockTime, err := analytics.ChainDiscovery(exp.Client, transactionX, txIndex)
 	if err != nil {
-		exp.StatusHandler(w, r, err)
+		exp.StatusHandler(w, r, t, err)
 		return
 	}
 
-	strData, err := json.Marshal(chain)
-	if err != nil {
-		exp.StatusHandler(w, r, fmt.Errorf("error occured: %v", err))
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(http.StatusOK)
-	w.Write(strData)
+	exp.handleJSONWrite(
+		pathSolution{
+			Data: chain,
+			TimeData: TimeData{
+				BlockTime: blockTime, Duration: time.Since(t).String(),
+			},
+		},
+		http.StatusOK, t, w, r)
 }
 
 // PprofHandler fetches the correct pprof handler needed.
@@ -168,4 +193,24 @@ func (exp *explorer) PprofHandler(w http.ResponseWriter, r *http.Request) {
 	default:
 		pprof.Handler(handlerType).ServeHTTP(w, r)
 	}
+}
+
+// handleJSONWrite processes the payload data.
+func (exp *explorer) handleJSONWrite(rawData interface{}, status int,
+	t time.Time, w http.ResponseWriter, r *http.Request) {
+
+	byteData, err := json.Marshal(rawData)
+	if err != nil {
+		exp.StatusHandler(w, r, t, fmt.Errorf("error occured: %v", err))
+		return
+	}
+
+	jsonWrite(byteData, status, w)
+}
+
+// jsonWrite sends back the json payload.
+func jsonWrite(data []byte, status int, w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	w.Write(data)
 }

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/logrotate v1.0.0
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/onsi/ginkgo v1.6.0
 	golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac // indirect
 	golang.org/x/net v0.0.0-20180821023952-922f4815f713 // indirect
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect

--- a/rpcutils/common.go
+++ b/rpcutils/common.go
@@ -2,15 +2,11 @@
 // See LICENSE for details.
 package rpcutils
 
-import (
-	"time"
-)
-
 // Block describes part of the block information trimmed from the block data
 // by the rpc client.
 type Block struct {
 	Height       int64
-	Time         time.Time
+	Time         int64
 	Voters       uint16
 	FreshStake   uint8
 	Hash         string
@@ -22,6 +18,7 @@ type Block struct {
 // Transaction holds generic block transaction data that contains both the
 // transaction's input or output data.
 type Transaction struct {
+	BlockTime   int64
 	TxID        string
 	TxType      int64
 	TxTree      int8

--- a/rpcutils/extract.go
+++ b/rpcutils/extract.go
@@ -21,7 +21,7 @@ func ExtractBlockData(blockData *wire.MsgBlock) *Block {
 		Hash:         blockData.BlockHash().String(),
 		MerkleRoot:   blockHeader.MerkleRoot.String(),
 		Height:       int64(blockHeader.Height),
-		Time:         blockHeader.Timestamp,
+		Time:         blockHeader.Timestamp.Unix(),
 		FreshStake:   blockHeader.FreshStake,
 		Voters:       blockHeader.Voters,
 		StakeRoot:    blockHeader.StakeRoot.String(),
@@ -33,15 +33,16 @@ func ExtractBlockData(blockData *wire.MsgBlock) *Block {
 // MsgBlock. Only the stake transactions data that is currently extracted.
 func ExtractBlockTransactions(blockData *wire.MsgBlock,
 	activeNet networkconfig.NetworkType) []*Transaction {
-	// block := ExtractBlockData(blockData)
+	block := ExtractBlockData(blockData)
 	sTxs := blockData.STransactions
 	txs := make([]*Transaction, len(sTxs))
 
 	for index, sTx := range sTxs {
 		tx := &Transaction{
-			TxID:   sTx.TxHash().String(),
-			TxType: int64(stake.DetermineTxType(sTx)),
-			TxTree: wire.TxTreeStake,
+			TxID:      sTx.TxHash().String(),
+			TxType:    int64(stake.DetermineTxType(sTx)),
+			TxTree:    wire.TxTreeStake,
+			BlockTime: block.Time,
 		}
 
 		var sent, spent float64
@@ -118,6 +119,7 @@ func ExtractRawTxTransaction(rawTx *dcrjson.TxRawResult) *Transaction {
 	tx.Inpoints = vins
 	tx.NumInpoint = uint32(len(vins))
 	tx.Sent = sent
+	tx.BlockTime = rawTx.Blocktime
 
 	vouts := make([]TxOutput, len(rawTx.Vout))
 


### PR DESCRIPTION
This PR adds the following modifications.
- Scans coinjoin tx funds flow paths only - scans only where the path probability is between 1 and 0 (path probability is always formatted to an 8 digit number. Scan not limited by depth. 1 and 0 are exclusive.
- Adds the BlockTime and Durations fields to the root of the payload.
- Adds complex transaction definition and blocks further processing of complex tx. (This is a temporary measure just to ensure processing complex txs doesn't block processing other faster transactions)..